### PR TITLE
Change bot to comment on PR instead

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -27,9 +27,8 @@ async function main() {
   // An authenticated instance of `@octokit/rest`
   const octokit = tools.github;
 
-  await octokit.repos.createCommitComment({
-    ...tools.context.repo,
-    sha: tools.context.sha,
+  await octokit.issues.createComment({
+    ...tools.context.issue,
     body: resultsAsMarkdown
   });
 
@@ -76,7 +75,7 @@ function convertToMarkdown(results) {
     )
     .join("\n");
 
-  let shortSha = tools.context.sha.slice(0,7);
+  let shortSha = tools.context.sha.slice(0, 7);
   return `## Benchmark for ${shortSha}
   <details>
     <summary>Click to view benchmark</summary>


### PR DESCRIPTION
Tested here:
https://github.com/jasonwilliams/boa/pull/108

It's working, however 1 more thing to clean up here:
```
Deprecation: [@octokit/rest] "number" parameter is deprecated for ".issues.createComment()". Use "issue_number" instead
    at /node_modules/@octokit/rest/plugins/register-endpoints/register-endpoints.js:71:26
    at Array.forEach (<anonymous>)
    at Object.patchedMethod [as createComment] (/node_modules/@octokit/rest/plugins/register-endpoints/register-endpoints.js:67:26)
    at main (/entrypoint.js:30:24)
    at processTicksAndRejections (internal/process/task_queues.js:88:5)
    at async /entrypoint.js:94:5 {
  name: 'Deprecation'
```

Might be worth me updating this