### PR TITLE
Fix bug in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: criterion-compare
 author: Matan Kushner <hello@matchai.dev>
 description: Compare the performance of a PR against master
-run:
+runs:
   using: 'docker'
   image: 'Dockerfile'
 branding:


### PR DESCRIPTION
We trying to integrate it, and it fails with 
```
##[error]Top level 'runs:' section is required for /home/runner/work/_actions/matchai/criterion-compare-action/master/action.yml
```

This PR should fix it, ~~but I haven't checked it yet~~ and it does.